### PR TITLE
치명적인 이슈 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muffinbot",
-  "version": "3.0.1-cake.r240815b",
+  "version": "3.0.2-cake.r240924a",
   "main": "dist/index.js",
   "private": true,
   "dependencies": {

--- a/src/Commands/deleteLearn.ts
+++ b/src/Commands/deleteLearn.ts
@@ -24,6 +24,7 @@ import { type LearnData } from '../modules'
 })
 class DeleteLearnCommand extends Command {
   public async messageRun(msg: Message, args: Args) {
+    const CUSTOM_ID = 'maa$deleteLearn'
     const command = await args.rest('string').catch(() => null)
     const options: SelectMenuComponentOptionData[] = []
     const db = this.container.database
@@ -46,7 +47,7 @@ class DeleteLearnCommand extends Command {
       console.log(data)
       options.push({
         label: `${data.id}번`,
-        value: `maa$deleteLearn-${data.id}`,
+        value: `${CUSTOM_ID}-${data.id}`,
         description: data.result.slice(0, 100),
       })
     })
@@ -68,7 +69,7 @@ class DeleteLearnCommand extends Command {
           components: [
             {
               type: ComponentType.StringSelect,
-              customId: 'maa$deleteLearn',
+              customId: `${CUSTOM_ID}@${msg.author.id}`,
               placeholder: '지울 데이터를 선택해ㅈ주세요',
               options,
             },

--- a/src/interaction-handlers/deleteLearn.ts
+++ b/src/interaction-handlers/deleteLearn.ts
@@ -10,15 +10,25 @@ import { ApplyOptions } from '@sapphire/decorators'
   interactionHandlerType: InteractionHandlerTypes.SelectMenu,
 })
 class DeleteLearnHandler extends InteractionHandler {
+  private readonly _CUSTOM_ID = 'maa$deleteLearn'
+
   public async parse(interaction: StringSelectMenuInteraction) {
-    if (interaction.customId !== 'maa$deleteLearn') return this.none()
+    if (!interaction.customId.startsWith(this._CUSTOM_ID)) return this.none()
+    const userId = interaction.customId.slice(`${this._CUSTOM_ID}@`.length)
+    if (interaction.user.id !== userId) {
+      await interaction.reply({
+        ephemeral: true,
+        content: '당신은 이 지ㅅ식을 안 가르쳐 주셨어요.',
+      })
+      return this.none()
+    }
     return this.some()
   }
 
   public async run(interaction: StringSelectMenuInteraction) {
     await interaction.deferUpdate()
 
-    const id = interaction.values[0].slice('maa$deleteLearn-'.length)
+    const id = interaction.values[0].slice(`${this._CUSTOM_ID}-`.length)
     const db = this.container.database
 
     await db.learn.delete(id)


### PR DESCRIPTION
- 이슈 내용: 다른 사람이 머핀아 삭제를 하여 셀렉트 메뉴가 뜬 상태로 명령어를 쓰지 아니한 다른 사람이 해당 지식을 삭제 할 수가 있음.
- 해결 내용: select menu의 custom_id에 user의 ID값을 넣어 그 값을 토대로 상호작용을 할려는 유저의 ID와 비교하여 ID가 틀릴 시 삭제 불가능 하도록 조치